### PR TITLE
Fix build and run targets of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,9 @@
 .PHONY: build-arm build-linux build-mac clean cov fmt help vet test
 
 ## build-arm: build binary for ARM
-build-arm:
-	export GO111MODULE=on
+build:
 	chmod u+x ./scripts/build
-	./scripts/build linux arm
-
-## build-linux: build binary for Linux
-build-linux:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build linux amd64
-
-## build-mac: build binary for Mac
-build-mac:
-	export GO111MODULE=on
-	chmod u+x ./scripts/build
-	./scripts/build darwin amd64
+	./scripts/build
 
 ## clean: cleans the binary
 clean:
@@ -40,14 +27,10 @@ help:
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
 
 ## run-linux: Run locally with default configuration
-run-linux: clean build-linux
+run: clean
+	export FEEDER_CONFIG_PATH=./config.example.json; \
 	export FEEDER_LOG_LEVEL=5; \
-	./build/feederd-linux-amd64
-
-## run-mac: Run locally with default configuration
-run-mac: clean build-mac
-	export FEEDER_LOG_LEVEL=5; \
-	./build/feederd-darwin-amd64
+	go run cmd/feederd/main.go
 
 ## vet: code analysis
 vet:

--- a/scripts/build
+++ b/scripts/build
@@ -7,7 +7,10 @@ PARENT_PATH=$(dirname $(
   pwd -P
 ))
 
+OS=$(eval "go env GOOS")
+ARCH=$(eval "go env GOARCH")
+
 pushd $PARENT_PATH
 mkdir -p build
-GOOS=$1 GOARCH=$2 go build -ldflags="-s -w" -o build/feederd-$1-$2 cmd/feederd/main.go
+GO111MODULE=on go build -ldflags="-s -w" -o build/feederd-$OS-$ARCH cmd/feederd/main.go
 popd


### PR DESCRIPTION
This changes the makefile and the build script so that we have only one `make build` and one `make run` and not one per each platform. Also, the `make run` changes so that it calls `go run` instead of building and running the binary.

These changes are required for [#333](https://github.com/TDex-network/tdex-daemon/issues/333).

Please @tiero review this.