### PR TITLE
Update stubs location to v0.8.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c
+	github.com/tdex-network/tdex-daemon v0.8.12
 	github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20220330150215-afd1e97f790e
 	google.golang.org/grpc v1.45.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tdex-network/tdex-daemon v0.8.11
+	github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c
 	github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20220330150215-afd1e97f790e
 	google.golang.org/grpc v1.45.0
 	gopkg.in/macaroon.v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -538,6 +538,8 @@ github.com/tdex-network/tdex-daemon v0.8.11 h1:0HsPQdIcsfdcSWarF+mZrlvssAQKCX4vL
 github.com/tdex-network/tdex-daemon v0.8.11/go.mod h1:C8XbigI/pbFur5AKGESgI3JnUO76dRSA5y/mYzv7k04=
 github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c h1:RqwOWZxoykuUsER6Fs6lNZ9e3gW4SlUlYZ81YCq0ABM=
 github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c/go.mod h1:C8XbigI/pbFur5AKGESgI3JnUO76dRSA5y/mYzv7k04=
+github.com/tdex-network/tdex-daemon v0.8.12 h1:AvbIgcXz9CN3z4xzf3ASKI4pDB0AekjYhNB+j5U5KJs=
+github.com/tdex-network/tdex-daemon v0.8.12/go.mod h1:C8XbigI/pbFur5AKGESgI3JnUO76dRSA5y/mYzv7k04=
 github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20210322164638-77a31ea9e66d/go.mod h1:4gMUHFqbQCzBULCsmoyuvFKXX1Yr6a6r6qyhlTtR+KM=
 github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20211001103242-a11e4485705a/go.mod h1:0x7R122qN31xARZrTqLICscV2k3w1q85pTzyb3AjJco=
 github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20210813140257-70d50a8b72a4/go.mod h1:JNwFSeCsjtNtzw4Eltr+sJVQT49d3GA6yGFpBg14WEE=

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,8 @@ github.com/tdex-network/tdex-daemon v0.8.7 h1:4TVUikTNKiV2iZEz1oPz4Aoo9LYQriK66M
 github.com/tdex-network/tdex-daemon v0.8.7/go.mod h1:yYzHE29GWN2mYooLAu+TYz9vX9D2kNs4KEAAWAuDyEc=
 github.com/tdex-network/tdex-daemon v0.8.11 h1:0HsPQdIcsfdcSWarF+mZrlvssAQKCX4vLoZ/sGb/8R8=
 github.com/tdex-network/tdex-daemon v0.8.11/go.mod h1:C8XbigI/pbFur5AKGESgI3JnUO76dRSA5y/mYzv7k04=
+github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c h1:RqwOWZxoykuUsER6Fs6lNZ9e3gW4SlUlYZ81YCq0ABM=
+github.com/tdex-network/tdex-daemon v0.8.12-rc.0.0.20220503122146-5f907890261c/go.mod h1:C8XbigI/pbFur5AKGESgI3JnUO76dRSA5y/mYzv7k04=
 github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20210322164638-77a31ea9e66d/go.mod h1:4gMUHFqbQCzBULCsmoyuvFKXX1Yr6a6r6qyhlTtR+KM=
 github.com/tdex-network/tdex-daemon/pkg/explorer v0.0.0-20211001103242-a11e4485705a/go.mod h1:0x7R122qN31xARZrTqLICscV2k3w1q85pTzyb3AjJco=
 github.com/tdex-network/tdex-daemon/pkg/macaroons v0.0.0-20210813140257-70d50a8b72a4/go.mod h1:JNwFSeCsjtNtzw4Eltr+sJVQT49d3GA6yGFpBg14WEE=

--- a/internal/core/infrastructure/client/grpc/service.go
+++ b/internal/core/infrastructure/client/grpc/service.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"gopkg.in/macaroon.v2"
 
-	pb "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex-daemon/v1"
-	pbtypes "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/go/tdex/v1"
+	pb "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/tdex-daemon/v1"
+	pbtypes "github.com/tdex-network/tdex-daemon/api-spec/protobuf/gen/tdex/v1"
 )
 
 var (


### PR DESCRIPTION
Needs 0.8.12 tag on tdex-daemon﻿
